### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/hemantDwivedi/password-generator-tool/security/code-scanning/1](https://github.com/hemantDwivedi/password-generator-tool/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted regardless of repo/org defaults.

Best single fix here: in `.github/workflows/maven.yml`, add a root-level permissions section after the `on` triggers and before `jobs`:

- `permissions:`
- `  contents: read`

This preserves current functionality (checkout + Maven build) while enforcing least privilege for all jobs in the workflow. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
